### PR TITLE
Add placeholder worker task implementations

### DIFF
--- a/apps/worker/tasks/__init__.py
+++ b/apps/worker/tasks/__init__.py
@@ -1,0 +1,12 @@
+"""Background task placeholders for the worker service."""
+
+from .ocr import process_ocr
+from .embed import embed_document
+from .zip import create_zip
+
+__all__ = [
+    "process_ocr",
+    "embed_document",
+    "create_zip",
+]
+

--- a/apps/worker/tasks/embed.py
+++ b/apps/worker/tasks/embed.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def embed_document(*args, **kwargs) -> None:
+    """Placeholder embedding task."""
+    logger.info("Running embed_document task", extra={"args": args, "kwargs": kwargs})
+

--- a/apps/worker/tasks/ocr.py
+++ b/apps/worker/tasks/ocr.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def process_ocr(*args, **kwargs) -> None:
+    """Placeholder OCR processing task."""
+    logger.info("Running process_ocr task", extra={"args": args, "kwargs": kwargs})
+

--- a/apps/worker/tasks/zip.py
+++ b/apps/worker/tasks/zip.py
@@ -1,0 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def create_zip(*args, **kwargs) -> None:
+    """Placeholder zip creation task."""
+    logger.info("Running create_zip task", extra={"args": args, "kwargs": kwargs})
+


### PR DESCRIPTION
## Summary
- implement placeholder tasks in `apps/worker/tasks`
- expose tasks from `apps/worker/tasks/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580f7284f8832782ebcea64f25ba3b