### PR TITLE
Initialize FastAPI app with stub routes

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,0 +1,18 @@
+"""FastAPI application entrypoint."""
+
+from fastapi import FastAPI
+
+from .routes import router as api_router
+
+
+app = FastAPI(title="VisaMate API")
+
+
+@app.get("/healthz")
+async def health_check() -> dict[str, str]:
+    """Simple health probe."""
+    return {"status": "ok"}
+
+
+app.include_router(api_router)
+

--- a/apps/api/routes/__init__.py
+++ b/apps/api/routes/__init__.py
@@ -1,0 +1,29 @@
+"""Aggregate API routers."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from pathlib import Path
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+def _include_all_routers() -> None:
+    package_dir = Path(__file__).resolve().parent
+    package_name = __name__
+    for module_info in pkgutil.iter_modules([str(package_dir)]):
+        name = module_info.name
+        if name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{package_name}.{name}")
+        module_router = getattr(module, "router", None)
+        if module_router is not None:
+            router.include_router(module_router, prefix=f"/{name}")
+
+
+_include_all_routers()
+

--- a/apps/api/routes/auth.py
+++ b/apps/api/routes/auth.py
@@ -1,0 +1,13 @@
+"""Authentication related routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def auth_root() -> dict[str, str]:
+    """Placeholder endpoint for auth."""
+    return {"status": "auth"}
+

--- a/apps/api/routes/colleges.py
+++ b/apps/api/routes/colleges.py
@@ -1,0 +1,13 @@
+"""College lookup routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_colleges() -> dict[str, str]:
+    """Return placeholder college list."""
+    return {"result": "colleges"}
+

--- a/apps/api/routes/documents.py
+++ b/apps/api/routes/documents.py
@@ -1,0 +1,13 @@
+"""Document management routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_documents() -> dict[str, str]:
+    """Return placeholder document list."""
+    return {"result": "documents"}
+

--- a/apps/api/routes/notify.py
+++ b/apps/api/routes/notify.py
@@ -1,0 +1,13 @@
+"""Notification routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def notify_placeholder() -> dict[str, str]:
+    """Return placeholder notification response."""
+    return {"result": "notify"}
+

--- a/apps/api/routes/profile.py
+++ b/apps/api/routes/profile.py
@@ -1,0 +1,13 @@
+"""User profile routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def get_profile() -> dict[str, str]:
+    """Return placeholder profile."""
+    return {"result": "profile"}
+

--- a/apps/api/routes/sop.py
+++ b/apps/api/routes/sop.py
@@ -1,0 +1,13 @@
+"""Statement of Purpose generation routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def generate_sop() -> dict[str, str]:
+    """Return placeholder SOP."""
+    return {"result": "sop"}
+

--- a/apps/api/routes/visa.py
+++ b/apps/api/routes/visa.py
@@ -1,0 +1,13 @@
+"""Visa application routes."""
+
+from fastapi import APIRouter
+
+
+router = APIRouter()
+
+
+@router.get("/")
+async def visa_status() -> dict[str, str]:
+    """Return placeholder visa info."""
+    return {"result": "visa"}
+


### PR DESCRIPTION
## Summary
- create FastAPI application in `apps/api/main.py`
- dynamically load all route modules via `apps/api/routes`
- add placeholder endpoints for auth, colleges, documents, notifications, profile, SOP and visa routes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68580f65cabc8327942739794a054922