### PR TITLE
Add minimal Docker setup

### DIFF
--- a/compose/api/Dockerfile
+++ b/compose/api/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /code
+COPY . /code
+RUN pip install --no-cache-dir fastapi uvicorn[standard]
+CMD ["uvicorn", "apps.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/compose/worker/Dockerfile
+++ b/compose/worker/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /code
+COPY . /code
+RUN pip install --no-cache-dir celery
+CMD ["python", "-m", "apps.worker"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,59 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: visamate
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+
+  api:
+    build:
+      context: .
+      dockerfile: compose/api/Dockerfile
+    env_file: .env.dev
+    volumes:
+      - .:/code
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+      - redis
+      - minio
+
+  worker:
+    build:
+      context: .
+      dockerfile: compose/worker/Dockerfile
+    env_file: .env.dev
+    volumes:
+      - .:/code
+    depends_on:
+      - postgres
+      - redis
+
+volumes:
+  pgdata:
+  minio-data:


### PR DESCRIPTION
## Summary
- add Dockerfiles for api and worker containers
- create a development docker-compose stack with postgres, redis, minio

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68580f8446008327a9d231b9d3af06e7