### PR TITLE
Add core models and migrations

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,25 @@
+[alembic]
+script_location = db/migrations
+sqlalchemy.url = sqlite:///./app.db
+
+[loggers]
+keys = root
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/db/init_db.py
+++ b/db/init_db.py
@@ -1,0 +1,9 @@
+from sqlalchemy import create_engine
+
+from models import Base  # noqa: F401
+
+
+def init_db(url: str) -> None:
+    """Create all tables for the given database URL."""
+    engine = create_engine(url)
+    Base.metadata.create_all(bind=engine)

--- a/db/migrations/env.py
+++ b/db/migrations/env.py
@@ -1,0 +1,41 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from models import Base
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/db/migrations/versions/0001_create_core_tables.py
+++ b/db/migrations/versions/0001_create_core_tables.py
@@ -1,0 +1,51 @@
+"""create core tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("email", sa.String(), nullable=False, unique=True, index=True),
+        sa.Column("hashed_password", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("role", sa.String(), nullable=False, server_default="student"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "documents",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("filename", sa.String(), nullable=False),
+        sa.Column("content_type", sa.String(), nullable=False),
+        sa.Column("url", sa.String(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "checklists",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("user_id", sa.Integer, sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("items", sa.JSON(), nullable=False),
+        sa.Column("is_complete", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("checklists")
+    op.drop_table("documents")
+    op.drop_table("users")

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,11 @@
+from .base import Base
+from .user import User
+from .document import Document
+from .checklist import Checklist
+
+__all__ = [
+    "Base",
+    "User",
+    "Document",
+    "Checklist",
+]

--- a/models/base.py
+++ b/models/base.py
@@ -1,0 +1,10 @@
+from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, DateTime, func
+
+Base = declarative_base()
+
+class TimestampMixin:
+    """Mixin with created/updated timestamps."""
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())

--- a/models/checklist.py
+++ b/models/checklist.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, Boolean, ForeignKey, JSON
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+class Checklist(Base, TimestampMixin):
+    """Track completion of required documents."""
+
+    __tablename__ = "checklists"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    name = Column(String, nullable=False)
+    items = Column(JSON, nullable=False)
+    is_complete = Column(Boolean, nullable=False, server_default='0')
+
+    user = relationship("User", back_populates="checklists")

--- a/models/document.py
+++ b/models/document.py
@@ -1,0 +1,17 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, func
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+class Document(Base, TimestampMixin):
+    """User uploaded document."""
+
+    __tablename__ = "documents"
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    filename = Column(String, nullable=False)
+    content_type = Column(String, nullable=False)
+    url = Column(String, nullable=False)
+
+    user = relationship("User", back_populates="documents")

--- a/models/user.py
+++ b/models/user.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Boolean, Column, Integer, String, DateTime, func
+from sqlalchemy.orm import relationship
+
+from .base import Base, TimestampMixin
+
+class User(Base, TimestampMixin):
+    """Application user."""
+
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    hashed_password = Column(String, nullable=False)
+    is_active = Column(Boolean, nullable=False, server_default='1')
+    role = Column(String, nullable=False, server_default='student')
+
+    documents = relationship("Document", back_populates="user", cascade="all, delete-orphan")
+    checklists = relationship("Checklist", back_populates="user", cascade="all, delete-orphan")


### PR DESCRIPTION
## Summary
- create SQLAlchemy base with timestamp mixin
- define `User`, `Document`, and `Checklist` models
- expose models in `models/__init__.py`
- add Alembic environment and initial migration to create tables
- provide helper `init_db` utility

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68580f7e8bc483279a58cd60364fe318