### PR TITLE
Add env example and stub frontend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Application environment variables
+# Copy this file to .env.dev and fill in your credentials
+
+# Database
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=visamate
+
+# Third-party APIs
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_KEY=<your-supabase-key>
+CLOUDFLARE_ACCOUNT_ID=<your-cloudflare-account-id>
+CLOUDFLARE_API_TOKEN=<your-cloudflare-api-token>
+TOGETHER_API_KEY=<your-together-api-key>
+GEMINI_API_KEY=<your-gemini-api-key>
+PINECONE_API_KEY=<your-pinecone-api-key>
+PINECONE_ENVIRONMENT=<your-pinecone-environment>

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ T┌─────────────────────────�
 ```bash
 git clone https://github.com/<org>/visamate-ai.git
 cd visamate-ai
-cp .env.example .env.dev && nano .env.dev   # set Supabase, CF, Together keys
+cp .env.example .env.dev && nano .env.dev   # fill Supabase, Cloudflare, Together, Gemini & Pinecone keys
 docker compose -f docker-compose.dev.yml up --build
 open http://localhost:8000/docs   # Swagger UI
 ```
@@ -197,7 +197,7 @@ git clone https://github.com/<org>/visamate-ai.git
 cd visamate-ai
 
 # env vars
-cp .env.example .env.dev  # fill Supabase / Together AI keys
+cp .env.example .env.dev  # fill Supabase / Together AI / Gemini / Pinecone keys
 
 # bring up full stack (Postgres, Redis, MinIO, API, Worker)
 docker compose -f docker-compose.dev.yml up --build

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,6 @@
+# Frontend Prototype
+
+This folder contains a minimal HTML page acting as a placeholder UI.
+Use any preferred framework (React, Vue, etc.) to build the final design.
+
+Open `index.html` in your browser to see the demo page.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VisaMate</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 2rem; }
+        header { background: #004d99; color: white; padding: 1rem; }
+        main { margin-top: 2rem; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>VisaMate</h1>
+    </header>
+    <main>
+        <p>Welcome to the VisaMate demo interface.</p>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholder secrets
- update README quick-start notes with new env vars
- stub out `frontend` directory with simple HTML page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685813263f508327abbea658b5cca6ec