### PR TITLE
Add document upload endpoint and demo UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+uploads/

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ docker compose -f docker-compose.dev.yml up --build
 open http://localhost:8000/docs   # Swagger UI
 ```
 
+### Demo Document Upload
+
+1. Open `frontend/index.html` in your browser.
+2. Select a file and click **Upload**. The page submits to `/documents/upload` and shows the saved filename.
+
+
 ---
 
 ## 🌍 First Deploy (All Free‑Tier)

--- a/apps/api/routes/documents.py
+++ b/apps/api/routes/documents.py
@@ -1,6 +1,10 @@
 """Document management routes."""
 
-from fastapi import APIRouter
+from pathlib import Path
+
+from fastapi import APIRouter, File, UploadFile
+
+from services.documents import save_file
 
 
 router = APIRouter()
@@ -10,4 +14,12 @@ router = APIRouter()
 async def list_documents() -> dict[str, str]:
     """Return placeholder document list."""
     return {"result": "documents"}
+
+
+@router.post("/upload")
+async def upload_document(file: UploadFile = File(...)) -> dict[str, str]:
+    """Accept a document upload and store it locally."""
+    uploads_dir = Path("uploads")
+    await save_file(file, uploads_dir)
+    return {"filename": file.filename}
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,6 +16,24 @@
     </header>
     <main>
         <p>Welcome to the VisaMate demo interface.</p>
+        <form id="uploadForm" enctype="multipart/form-data">
+            <input type="file" name="file" required>
+            <button type="submit">Upload</button>
+        </form>
+        <p id="result"></p>
     </main>
+    <script>
+        const form = document.getElementById('uploadForm');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const formData = new FormData(form);
+            const resp = await fetch('/documents/upload', {
+                method: 'POST',
+                body: formData
+            });
+            const data = await resp.json();
+            document.getElementById('result').textContent = `Uploaded: ${data.filename}`;
+        });
+    </script>
 </body>
 </html>

--- a/services/documents/__init__.py
+++ b/services/documents/__init__.py
@@ -1,0 +1,6 @@
+"""Document-related service helpers."""
+
+from .uploader import save_file
+
+__all__ = ["save_file"]
+

--- a/services/documents/uploader.py
+++ b/services/documents/uploader.py
@@ -1,0 +1,15 @@
+"""Helpers for saving uploaded documents."""
+
+from pathlib import Path
+
+from fastapi import UploadFile
+
+
+async def save_file(file: UploadFile, dest_dir: Path) -> Path:
+    """Persist an uploaded file to ``dest_dir`` and return the path."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    file_path = dest_dir / file.filename
+    with file_path.open("wb") as f:
+        f.write(await file.read())
+    return file_path
+

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,21 @@
+"""Tests for the document upload endpoint."""
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+client = TestClient(app)
+
+
+def test_upload_document(tmp_path: Path) -> None:
+    upload_path = tmp_path / "sample.txt"
+    upload_path.write_text("example")
+
+    with upload_path.open("rb") as f:
+        response = client.post("/documents/upload", files={"file": f})
+
+    assert response.status_code == 200
+    assert response.json()["filename"] == "sample.txt"


### PR DESCRIPTION
## Summary
- enable uploads via `/documents/upload`
- store files under a local `uploads` directory
- expose a helper function in `services.documents`
- provide a simple frontend form to send files
- document the upload demo in the README
- add test for the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858315509c08327a28317370b6a2cf5